### PR TITLE
fix(sudoku): 더블클릭 확대 및 텍스트 선택 오류 수정

### DIFF
--- a/games/sudoku/style.css
+++ b/games/sudoku/style.css
@@ -11,6 +11,10 @@ body {
     min-height: 100vh;
     padding: 20px;
     -webkit-tap-highlight-color: transparent;
+    user-select: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
 }
 
 .container {
@@ -109,6 +113,7 @@ body {
     color: white;
     cursor: pointer;
     transition: all 0.3s ease;
+    touch-action: manipulation;
 }
 
 .difficulty-btn:hover, .difficulty-btn.active {
@@ -201,6 +206,7 @@ body {
     background-color: rgba(255, 255, 255, 0.15);
     color: white;
     transition: all 0.2s;
+    touch-action: manipulation;
 }
 .number-btn:hover {
     background-color: rgba(255, 255, 255, 0.3);
@@ -222,6 +228,7 @@ body {
     font-weight: bold;
     cursor: pointer;
     transition: all 0.3s ease;
+    touch-action: manipulation;
 }
 .control-btn:hover {
     transform: translateY(-2px);
@@ -258,6 +265,7 @@ body {
     border: none; border-radius: 25px; padding: 12px 25px;
     color: white; font-size: 1rem; font-weight: bold;
     cursor: pointer; transition: all 0.3s ease;
+    touch-action: manipulation;
 }
 .modal-btn:hover {
     transform: translateY(-2px);


### PR DESCRIPTION
- 요청 사항:
  1. 각종 버튼 더블클릭 시 화면이 확대되는 이슈 해결
  2. 게임 진행 중 텍스트가 선택되는 현상 방지

- 개선안:
  1. 모든 버튼 클래스(`.difficulty-btn`, `.number-btn`, `.control-btn`, `.modal-btn`)에 `touch-action: manipulation;` CSS 속성을 추가하여 모바일 브라우저의 더블탭-줌 기능을 비활성화했습니다.
  2. `body` 태그에 `user-select: none;` CSS 속성을 적용하여 앱 전체에서 텍스트 선택이 일어나지 않도록 방지했습니다.