### PR TITLE
fix(sudoku): 전체 화면 더블클릭 확대 현상 수정

### DIFF
--- a/games/sudoku/index.html
+++ b/games/sudoku/index.html
@@ -2,7 +2,7 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>🧩 스도쿠 게임</title>
     <link rel="stylesheet" href="style.css">
 </head>


### PR DESCRIPTION
- 요청 사항: 화면의 어느 곳을 더블클릭해도 확대되지 않도록 수정을 요청했습니다.

- 개선안: `games/sudoku/index.html` 파일의 `<meta name="viewport">` 태그에 `maximum-scale=1.0` 속성을 추가했습니다. 이 속성은 웹 페이지의 최대 확대 비율을 1.0으로 고정하여, 모바일 브라우저에서 사용자가 화면을 확대하는 모든 동작(더블탭 포함)을 비활성화합니다.