### PR TITLE
fix(sudoku): Safari 확대/축소 방지 기능 강화

### DIFF
--- a/games/sudoku/script.js
+++ b/games/sudoku/script.js
@@ -1,4 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
+    // Safari 등에서 더블클릭으로 확대되는 것을 막기 위한 추가 조치
+    window.addEventListener('dblclick', (e) => {
+        e.preventDefault();
+    }, { passive: false });
+
     // --- DOM 요소 및 게임 상태 변수 ---
     const boardElement = document.getElementById('sudoku-board');
     const numberPalette = document.getElementById('number-palette');

--- a/games/sudoku/style.css
+++ b/games/sudoku/style.css
@@ -15,6 +15,7 @@ body {
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
+    touch-action: manipulation;
 }
 
 .container {


### PR DESCRIPTION
- 요청 사항: Safari 브라우저에서 화면 더블클릭 시 확대되는 현상을 확실히 해결해달라고 요청했습니다.

- 개선안: 기존의 viewport 메타 태그 수정만으로는 최신 Safari 브라우저에서 확대 방지가 완벽하지 않을 수 있어, 두 가지 방법을 추가로 적용했습니다.
  1. CSS: `body` 태그에 `touch-action: manipulation;` 속성을 추가하여 페이지 전역에서 더블탭 제스처로 인한 확대 동작을 억제했습니다.
  2. JavaScript: `window`에 `dblclick` 이벤트 리스너를 추가하고 `event.preventDefault()`를 호출하여, 더블클릭으로 인한 확대/축소 기본 동작을 명시적으로 차단하는 로직을 추가했습니다.