### PR TITLE
기능: 미사일 강화 로직 개선

### DIFF
--- a/games/bullethell/lib/ship.js
+++ b/games/bullethell/lib/ship.js
@@ -130,12 +130,20 @@
   };
 
   Ship.prototype.fireBullet = function() {
-    const spreadAngle = 15;
-    const totalAngle = (this.missileLevel - 1) * spreadAngle;
+    const MAX_SPREAD_LEVEL = 5;
+    const BASE_SPREAD_ANGLE = 15; // The angle between missiles at lower levels
+
+    // Cap the spread width at level 5
+    const effectiveSpreadLevel = Math.min(this.missileLevel, MAX_SPREAD_LEVEL);
+    const totalAngle = (effectiveSpreadLevel - 1) * BASE_SPREAD_ANGLE;
+
+    // For level 1, angleStep is 0. For >1, calculate step to fill totalAngle
+    const angleStep = this.missileLevel > 1 ? totalAngle / (this.missileLevel - 1) : 0;
+
     const startAngle = -totalAngle / 2;
 
     for (let i = 0; i < this.missileLevel; i++) {
-        const angle = startAngle + i * spreadAngle;
+        const angle = startAngle + i * angleStep;
         const rad = angle * (Math.PI / 180);
         const vel = [Math.sin(rad) * 8, -Math.cos(rad) * 8];
         const bullet = new BHGame.Bullet(this.pos.slice(), vel, this.game);


### PR DESCRIPTION
사용자 피드백을 반영하여 미사일 강화 아이템의 작동 방식을 개선했습니다.

### 주요 변경사항

*   `ship.js`의 `fireBullet` 메소드를 수정했습니다.
*   미사일 레벨이 5 이상으로 증가할 경우, 발사되는 부채꼴의 총 각도는 더 이상 넓어지지 않습니다.
*   대신, 제한된 각도 내에서 미사일이 더 촘촘하게 발사되도록 수정하여 고레벨에서의 무기 효율을 높였습니다.