### PR TITLE
체스 게임에 체크, 체크메이트, 스테일메이트 등 기본적인 게임 종료 규칙을 추가합니다.

### DIFF
--- a/games/chess/script.js
+++ b/games/chess/script.js
@@ -29,6 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let selectedPieceElement = null;
     let possibleMoves = [];
     let currentPlayer = W;
+    let isGameOver = false;
 
     function renderBoard() {
         boardElement.innerHTML = '';
@@ -56,6 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function handleSquareClick(e) {
+        if (isGameOver) return;
         const square = e.currentTarget;
         const index = parseInt(square.dataset.index);
         const piece = boardState[index];
@@ -125,14 +127,48 @@ document.addEventListener('DOMContentLoaded', () => {
         currentPlayer = (currentPlayer === W) ? BL : W;
         updateGameInfo();
 
-        if (currentPlayer === BL) {
+        checkGameOver();
+
+        if (currentPlayer === BL && !isGameOver) {
+            // It's AI's turn, and the game is not over.
             setTimeout(aiMove, 1000);
+        }
+    }
+
+    function checkGameOver() {
+        if (isGameOver) return;
+
+        let hasLegalMoves = false;
+        for (let i = 0; i < 64; i++) {
+            const piece = boardState[i];
+            if (piece && piece.color === currentPlayer) {
+                const moves = getValidMoves(piece, i);
+                if (moves.length > 0) {
+                    hasLegalMoves = true;
+                    break;
+                }
+            }
+        }
+
+        if (!hasLegalMoves) {
+            isGameOver = true;
+            const kingIndex = boardState.findIndex(p => p && p.piece === K && p.color === currentPlayer);
+            const opponentColor = currentPlayer === W ? BL : W;
+
+            if (isSquareAttacked(kingIndex, opponentColor)) {
+                const winner = opponentColor === W ? '백' : '흑';
+                gameInfoElement.textContent = `체크메이트! ${winner}의 승리!`;
+                alert(`체크메이트! ${winner}의 승리!`);
+            } else {
+                gameInfoElement.textContent = "스테일메이트! 무승부입니다.";
+                alert("스테일메이트! 무승부입니다.");
+            }
         }
     }
 
     function aiMove() {
         const allPossibleMoves = [];
-        for (let i = 0; i < boardState.length; i++) {
+        for (let i = 0; i < 64; i++) {
             const piece = boardState[i];
             if (piece && piece.color === BL) {
                 const moves = getValidMoves(piece, i);
@@ -145,11 +181,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (allPossibleMoves.length > 0) {
             const randomMove = allPossibleMoves[Math.floor(Math.random() * allPossibleMoves.length)];
             movePiece(randomMove.from, randomMove.to);
-        } else {
-            // This could be a stalemate or checkmate
-            gameInfoElement.textContent = "플레이어가 승리했습니다!";
-            alert("축하합니다! 플레이어가 승리했습니다!");
         }
+        // The case of no moves is handled by checkGameOver now.
     }
 
     function updateGameInfo() {
@@ -160,7 +193,102 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function isSquareAttacked(squareIndex, attackerColor) {
+        for (let i = 0; i < 64; i++) {
+            const piece = boardState[i];
+            if (piece && piece.color === attackerColor) {
+                const moves = getAttackMoves(piece, i);
+                if (moves.includes(squareIndex)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    // Generates attack moves for a piece, which can be different from regular moves (e.g., pawns).
+    function getAttackMoves(piece, index) {
+        // For king, we calculate raw attack squares without checking their safety to avoid recursion.
+        if (piece.piece === K) {
+            const moves = [];
+            const row = Math.floor(index / 8);
+            const col = index % 8;
+            const kingMoves = [
+                [-1, -1], [-1, 0], [-1, 1], [0, -1],
+                [0, 1], [1, -1], [1, 0], [1, 1]
+            ];
+            for (const [rowOffset, colOffset] of kingMoves) {
+                const newRow = row + rowOffset;
+                const newCol = col + colOffset;
+                if (newRow >= 0 && newRow < 8 && newCol >= 0 && newCol < 8) {
+                    moves.push(newRow * 8 + newCol);
+                }
+            }
+            return moves;
+        }
+
+        if (piece.piece === P) {
+            const moves = [];
+            const row = Math.floor(index / 8);
+            const col = index % 8;
+            const dir = piece.color === W ? -1 : 1;
+            const newRow = row + dir;
+
+            if (newRow >= 0 && newRow < 8) {
+                if (col > 0) moves.push(newRow * 8 + (col - 1));
+                if (col < 7) moves.push(newRow * 8 + (col + 1));
+            }
+            return moves;
+        }
+
+        // For other pieces, their attack squares are the same as their move squares.
+        // We pass the board state to handle captures correctly.
+        // We can't call getValidMoves here as it would lead to recursion with the king.
+        // So we call the specific move functions.
+        switch (piece.piece) {
+            case R: return getRookMoves(piece, index);
+            case N: return getKnightMoves(piece, index);
+            case B: return getBishopMoves(piece, index);
+            case Q: return getQueenMoves(piece, index);
+            default: return [];
+        }
+    }
+
     function getValidMoves(piece, index) {
+        // This function now generates all "legal" moves, considering checks.
+        const pseudoLegalMoves = getPseudoLegalMovesForPiece(piece, index);
+        const legalMoves = [];
+        const playerColor = piece.color;
+        const opponentColor = playerColor === W ? BL : W;
+
+        for (const move of pseudoLegalMoves) {
+            // Simulate the move
+            const originalDestinationPiece = boardState[move];
+            boardState[move] = piece;
+            boardState[index] = null;
+
+            // Find the king
+            let kingIndex = -1;
+            for (let i = 0; i < 64; i++) {
+                if (boardState[i] && boardState[i].piece === K && boardState[i].color === playerColor) {
+                    kingIndex = i;
+                    break;
+                }
+            }
+
+            // If the king is not attacked after the move, it's a legal move
+            if (kingIndex !== -1 && !isSquareAttacked(kingIndex, opponentColor)) {
+                legalMoves.push(move);
+            }
+
+            // Revert the move
+            boardState[index] = piece;
+            boardState[move] = originalDestinationPiece;
+        }
+        return legalMoves;
+    }
+
+    function getPseudoLegalMovesForPiece(piece, index) {
         switch (piece.piece) {
             case P: return getPawnMoves(piece, index);
             case R: return getRookMoves(piece, index);
@@ -269,6 +397,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const moves = [];
         const row = Math.floor(index / 8);
         const col = index % 8;
+        const opponentColor = piece.color === W ? BL : W;
         const kingMoves = [
             [-1, -1], [-1, 0], [-1, 1], [0, -1],
             [0, 1], [1, -1], [1, 0], [1, 1]
@@ -281,7 +410,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 const targetIndex = newRow * 8 + newCol;
                 const targetPiece = boardState[targetIndex];
                 if (!targetPiece || targetPiece.color !== piece.color) {
-                    moves.push(targetIndex);
+                    // Temporarily move king to check if the destination is safe
+                    const originalPiece = boardState[targetIndex];
+                    boardState[targetIndex] = piece;
+                    boardState[index] = null;
+
+                    if (!isSquareAttacked(targetIndex, opponentColor)) {
+                        moves.push(targetIndex);
+                    }
+
+                    // Revert the temporary move
+                    boardState[index] = piece;
+                    boardState[targetIndex] = originalPiece;
                 }
             }
         }


### PR DESCRIPTION
- 킹이 공격받고 있는지 확인하는 '체크' 로직을 구현했습니다.
- 킹이 스스로 위험한 위치로 이동할 수 없도록 수정했습니다.
- 플레이어는 자신의 킹이 체크 상태일 경우, 반드시 체크를 벗어나는 수만 둘 수 있습니다.
- 체크메이트 또는 스테일메이트 상황이 되면 게임이 종료되고 결과가 표시됩니다.