### PR TITLE
화면 너비가 좁을 때 잡은 기물 표시 영역과 체스판이 세로로 정렬되도록 CSS를 수정하여, 화면이 가운데 정렬되지 않던 문제…

### DIFF
--- a/games/chess/style.css
+++ b/games/chess/style.css
@@ -243,4 +243,18 @@ h1 {
         height: 40px;
         font-size: 32px;
     }
+
+    .game-area {
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    .captured-pieces {
+        width: 320px;
+        height: auto;
+        min-height: 30px;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+    }
 }


### PR DESCRIPTION
…를 해결합니다.