### PR TITLE
fix: Supabase 연결 오류 수정

### DIFF
--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -6,4 +6,6 @@ const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS
 // supabase-js CDN이 로드한 전역 supabase 객체의 createClient 함수를 사용하여 클라이언트를 생성합니다.
 // 생성된 클라이언트 인스턴스를 window.supabase에 할당하여 다른 스크립트에서 사용할 수 있도록 합니다.
 // 이렇게 하면 원래의 전역 supabase 객체를 클라이언트 인스턴스로 덮어쓰게 됩니다.
-window.supabase = supabase.createClient(supabaseUrl, supabaseKey);
+window.supabase = supabase.createClient(supabaseUrl, supabaseKey, {
+    db: { schema: 'public' },
+});


### PR DESCRIPTION
Supabase 클라이언트 초기화 시 `public` 스키마를 명시적으로 지정하여 API 요청 문제를 해결합니다.

- `supabaseClient.js`의 `createClient` 함수에 `db: { schema: 'public' }` 옵션을 추가했습니다.
- 이 변경으로 `portal_stats` 테이블 조회 시 발생하던 406 Not Acceptable 오류가 해결될 것으로 예상됩니다.
- 또한, 이 수정으로 인해 통계 업데이트 로직도 정상적으로 작동하여 클릭 통계가 올바르게 저장될 것입니다.