### PR TITLE
fix: 게임 카드 중복 클릭으로 인한 통계 중복 집계 오류 수정

### DIFF
--- a/script.js
+++ b/script.js
@@ -58,6 +58,16 @@ function updateStatsDisplay() {
 function handleGameNavigation(cardElement) {
     if (!cardElement) return;
 
+    // 중복 클릭 방지를 위해 버튼을 즉시 비활성화
+    const button = cardElement.querySelector('.play-button');
+    if (button && button.disabled) {
+        return; // 이미 처리 중인 경우 함수 종료
+    }
+    if (button) {
+        button.disabled = true;
+        button.textContent = '로딩중...'; // 사용자에게 상태 알림
+    }
+
     const gameName = cardElement.dataset.game;
     const href = cardElement.dataset.href;
 
@@ -159,6 +169,22 @@ async function initGamePortal() {
         }, 1000);
     }
 }
+
+// 뒤로가기 캐시(bfcache)에서 페이지 로드 시 버튼 상태 초기화
+function resetGameButtons() {
+    document.querySelectorAll('.play-button:disabled').forEach(button => {
+        if (button.textContent === '로딩중...') {
+            button.disabled = false;
+            button.textContent = '플레이하기';
+        }
+    });
+}
+
+// pageshow 이벤트는 사용자가 페이지를 다시 방문할 때마다 발생 (뒤로가기 포함)
+window.addEventListener('pageshow', function(event) {
+    // event.persisted가 true이면 bfcache에서 페이지가 로드된 것
+    resetGameButtons();
+});
 
 // 페이지 로드시 초기화
 document.addEventListener('DOMContentLoaded', initGamePortal);

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -6,6 +6,4 @@ const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS
 // supabase-js CDN이 로드한 전역 supabase 객체의 createClient 함수를 사용하여 클라이언트를 생성합니다.
 // 생성된 클라이언트 인스턴스를 window.supabase에 할당하여 다른 스크립트에서 사용할 수 있도록 합니다.
 // 이렇게 하면 원래의 전역 supabase 객체를 클라이언트 인스턴스로 덮어쓰게 됩니다.
-window.supabase = supabase.createClient(supabaseUrl, supabaseKey, {
-    db: { schema: 'public' },
-});
+window.supabase = supabase.createClient(supabaseUrl, supabaseKey);


### PR DESCRIPTION
게임 카드를 빠르게 중복 클릭할 경우, 비동기 요청이 여러 번 전송되어 통계가 중복으로 집계되는 문제를 해결합니다.

- `handleGameNavigation` 함수가 호출되면 즉시 '플레이하기' 버튼을 비활성화하고, 텍스트를 '로딩중...'으로 변경하여 추가 클릭을 방지합니다.
- `pageshow` 이벤트를 사용하여, 사용자가 '뒤로 가기'로 페이지에 다시 돌아왔을 때(bfcache) 비활성화된 버튼의 상태를 원래대로 복구합니다.

이 변경으로 사용자 경험을 해치지 않으면서 중복 요청을 안정적으로 방지할 수 있습니다.